### PR TITLE
Fix formation state toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -271,6 +271,13 @@ function updateStats() {
 }
 
 function switchState(newState) {
+    // If the user selects "formation" while already in that state and
+    // Consciousness Mode is active, exit the mode instead of reinitializing.
+    if (currentState === 'formation' && newState === 'formation' && isConsciousnessMode) {
+        exitConsciousnessMode();
+        return;
+    }
+
     if (currentState !== newState) {
         currentState = newState;
         


### PR DESCRIPTION
## Summary
- avoid re-entering Consciousness Mode when 'formation' is selected again

## Testing
- `node --check script.js`
- `node --check script-it.js`


------
https://chatgpt.com/codex/tasks/task_b_686bcc4494bc832a98c4bcb68482f970